### PR TITLE
refactored carousel code

### DIFF
--- a/src/css/Carousel.css
+++ b/src/css/Carousel.css
@@ -9,6 +9,8 @@
 .carousel .imageContainer {
   position: relative;
   margin: 0 auto;
+  max-height: 80vh;
+  aspect-ratio: 0.75;
 }
 
 .carousel .slide img {


### PR DESCRIPTION
* using a promise to make sure all images are loaded first before showing carousel
* removed window eventlistener on resize. too expensive.
* added aspect-ratio and max-height to image container seemed to fix tall images from overflowing out of the carousel div